### PR TITLE
Bump servant 0.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 dist-newstyle/
 *.log
+*.stack-work

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: haskell
 ghc:
   - 8.4.4
-  - 8.6.4
+  - 8.6.5
 cabal: 2.4
 
 install:

--- a/datadog-tracing.cabal
+++ b/datadog-tracing.cabal
@@ -38,7 +38,7 @@ common deps
                     , mtl                  ^>= 2.2.2
                     , text                 ^>= 1.2.3.1
                     , aeson                ^>= 1.4.1.0
-                    , servant              ^>= 0.14.1
+                    , servant              ^>= 0.15
   ghc-options:        -Wall
                       -Werror=missing-home-modules
   default-language:   Haskell2010
@@ -57,7 +57,7 @@ library
                     , msgpack         ^>= 1.0.1.0
                     , refined         ^>= 0.2.3.0 || ^>= 0.4
                     , prettyprinter   ^>= 1.2.1
-                    , servant-client  ^>= 0.14
+                    , servant-client  ^>= 0.15
                     , scientific      ^>= 0.3.6.2
                     , time            ^>= 1.8.0.2
                     , unordered-containers ^>= 0.2.9.0
@@ -71,7 +71,7 @@ executable datadog-agent
   main-is:            Main.hs
   build-depends:    , datadog-tracing
                     , data-default         ^>= 0.7.1.1
-                    , servant-server       ^>= 0.14.1
+                    , servant-server       ^>= 0.15
                     , wai-extra            ^>= 3.0.24 || ^>= 3.0.25
                     , warp                 ^>= 3.2.25
   ghc-options:        -threaded

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -1,0 +1,29 @@
+resolver: lts-12.26
+packages:
+  - '.'
+extra-deps:
+  - aeson-1.4.3.0
+  - base-orphans-0.8.1
+  - ffunctor-1.1.100
+  - free-5.1.1
+  - generics-sop-0.4.0.1 # remove when bumping to servant-0.16
+  - hspec-2.6.1
+  - hspec-core-2.6.1
+  - hspec-discover-2.6.1
+  - http-api-data-0.4
+  - jaeger-flamegraph-1.3.0
+  - msgpack-1.0.1.0
+  - network-2.8.0.1
+  # - network-3.0.1.1 # re-add when bumping to servant-0.16
+  - QuickCheck-2.12.6.1
+  - semigroupoids-5.3.2
+  - servant-0.15
+  - servant-client-0.15
+  - servant-client-core-0.15
+  - servant-server-0.15
+  # - simple-sendfile-0.2.28 # re-add when bumping to servant-0.16
+  - sop-core-0.4.0.0 # remove when bumping to servant-0.16
+  - splitmix-0.0.2
+  - tagged-0.8.6
+  # - wai-extra-3.0.26 # re-add when bumping to servant-0.16
+  # - warp-3.2.27 # re-add when bumping to servant-0.16

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,13 @@
+resolver: lts-13.22
+packages:
+  - .
+extra-deps:
+  - ffunctor-1.1.100
+  - jaeger-flamegraph-1.3.0
+  - msgpack-1.0.1.0
+  - refined-0.4.1
+  - servant-0.15
+  - servant-server-0.15
+  - servant-client-0.15
+  - servant-client-core-0.15
+  - tasty-1.1.0.4


### PR DESCRIPTION
This PR bumps the `servant` dependency to 0.15 and adds some stuff that lets `stack` users more easily build and test the project.

It also bumps the GHC version to 8.6.5 in the CI matrix.

I'm opening this PR separately from the `servant-0.16` PR, since this doesn't modify code at all and can be published as a Hackage revision.